### PR TITLE
Add two summarization papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ summary author.
 
 **8.Pointer + Coverage + EntailmentGen + QuestionGen** (Guo et al., 2018) : [Soft Layer-Specific Multi-Task Summarization with Entailment and Question Generation](http://aclweb.org/anthology/P18-1064)
 
+**9. Global semantics + Gating** (Nguyen et al., 2021): [Enriching and Controlling Global Semantics for Text Summarization](https://arxiv.org/abs/2109.10616)
+
+**10. Optimal transport distance + knowledge distillation** (Nguyen et al., 2021): [Improving Neural Cross-Lingual Summarization via Employing Optimal Transport Distance for Knowledge Distillation](https://arxiv.org/abs/2112.03473)
+
 ---
 
 


### PR DESCRIPTION
Hello,

Thank you for your wonderful survey!

Following your suggestion, I have created a pull request to add two summarization papers:

Paper 1: Enriching and Controlling Global Semantics for Text Summarization

Accepted at EMNLP 2021

The paper proposes to fuse global semantics of neural topic model and hidden representation of language model to improve document summarization quality.

Paper link: https://arxiv.org/abs/2109.10616

Paper 2: Improving Neural Cross-Lingual Summarization via Employing Optimal Transport Distance for Knowledge Distillation

Accepted at AAAI 2022

This work proposes a method to distill knowledge from monolingual summarization model into cross-lingual summarization model.

Paper link: https://arxiv.org/abs/2112.03473

Code link: https://github.com/nguyentthong/CrossSummOptimalTransport

Thank you a lot for your attention! 